### PR TITLE
Fix thumbnails not showing

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -1,23 +1,23 @@
-class Upload < ActiveRecord::Base
-  attr_accessible :upload
-  has_attached_file :upload,
-    styles: { 
-      original: "600x600>", 
-      thumbnail: "40x40#" 
-    }
+    class Upload < ActiveRecord::Base
+      attr_accessible :upload
+      has_attached_file :upload,
+        styles: { 
+          original: "600x600>", 
+          thumbnail: "40x40#" 
+        }
   
 
-  include Rails.application.routes.url_helpers
+      include Rails.application.routes.url_helpers
 
-  def to_jq_upload
-    {
-      "name" => read_attribute(:upload_file_name),
-      "size" => read_attribute(:upload_file_size),
-      "url" => upload.url(:original),
-      "delete_url" => upload_path(self),
-      "delete_type" => "DELETE",
-      "thumbnail_url" => upload.url(:thumbnail)
-    }
-  end
+      def to_jq_upload
+        {
+          "name" => read_attribute(:upload_file_name),
+          "size" => read_attribute(:upload_file_size),
+          "url" => upload.url(:original),
+          "delete_url" => upload_path(self),
+          "delete_type" => "DELETE",
+          "thumbnail_url" => upload.url(:thumbnail)
+        }
+      end
 
-end
+    end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -1,6 +1,11 @@
 class Upload < ActiveRecord::Base
   attr_accessible :upload
-  has_attached_file :upload
+  has_attached_file :upload,
+    styles: { 
+      original: "600x600>", 
+      thumbnail: "40x40#" 
+    }
+  
 
   include Rails.application.routes.url_helpers
 
@@ -10,7 +15,8 @@ class Upload < ActiveRecord::Base
       "size" => read_attribute(:upload_file_size),
       "url" => upload.url(:original),
       "delete_url" => upload_path(self),
-      "delete_type" => "DELETE" 
+      "delete_type" => "DELETE",
+      "thumbnail_url" => upload.url(:thumbnail)
     }
   end
 

--- a/app/views/uploads/_download_template.html
+++ b/app/views/uploads/_download_template.html
@@ -1,0 +1,29 @@
+<!-- The template to display files available for download -->
+<script id="template-download" type="text/x-tmpl">
+  {% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-download fade">
+      {% if (file.error) { %}
+        <td></td>
+        <td class="name"><span>{%=file.name%}</span></td>
+        <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
+        <td class="error" colspan="2"><span class="label label-important">{%=locale.fileupload.error%}</span> {%=locale.fileupload.errors[file.error] || file.error%}</td>
+        {% } else { %}
+        <td class="preview">{% if (file.thumbnail_url) { %}
+          <a href="{%=file.url%}" title="{%=file.name%}" rel="gallery" download="{%=file.name%}"><img src="{%=file.thumbnail_url%}"></a>
+          {% } %}</td>
+        <td class="name">
+          <a href="{%=file.url%}" title="{%=file.name%}" rel="{%=file.thumbnail_url&&'gallery'%}" download="{%=file.name%}">{%=file.name%}</a>
+        </td>
+        <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
+        <td colspan="2"></td>
+        {% } %}
+      <td class="delete">
+        <button class="btn btn-danger" data-type="{%=file.delete_type%}" data-url="{%=file.delete_url%}">
+          <i class="icon-trash icon-white"></i>
+          <span>{%=locale.fileupload.destroy%}</span>
+        </button>
+        <input type="checkbox" name="delete" value="1">
+      </td>
+    </tr>
+    {% } %}
+</script>

--- a/app/views/uploads/_upload_template.html
+++ b/app/views/uploads/_upload_template.html
@@ -1,0 +1,31 @@
+<!-- The template to display files available for upload -->
+<script id="template-upload" type="text/x-tmpl">
+  {% for (var i=0, file; file=o.files[i]; i++) { %}
+  <tr class="template-upload fade">
+    <td class="preview"><span class="fade"></span></td>
+    <td class="name"><span>{%=file.name%}</span></td>
+    <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
+    {% if (file.error) { %}
+    <td class="error" colspan="2"><span class="label label-important">{%=locale.fileupload.error%}</span> {%=locale.fileupload.errors[file.error] || file.error%}</td>
+    {% } else if (o.files.valid && !i) { %}
+    <td>
+      <div class="progress progress-success progress-striped active"><div class="bar" style="width:0%;"></div></div>
+    </td>
+    <td class="start">{% if (!o.options.autoUpload) { %}
+      <button class="btn btn-primary">
+        <i class="icon-upload icon-white"></i>
+        <span>{%=locale.fileupload.start%}</span>
+      </button>
+      {% } %}</td>
+    {% } else { %}
+    <td colspan="2"></td>
+    {% } %}
+    <td class="cancel">{% if (!i) { %}
+      <button class="btn btn-warning">
+        <i class="icon-ban-circle icon-white"></i>
+        <span>{%=locale.fileupload.cancel%}</span>
+      </button>
+      {% } %}</td>
+  </tr>
+  {% } %}
+</script>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -51,66 +51,8 @@
   };
 </script>
 
-<!-- The template to display files available for upload -->
-<script id="template-upload" type="text/x-tmpl">
-  {% for (var i=0, file; file=o.files[i]; i++) { %}
-  <tr class="template-upload fade">
-    <td class="preview"><span class="fade"></span></td>
-    <td class="name"><span>{%=file.name%}</span></td>
-    <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
-    {% if (file.error) { %}
-    <td class="error" colspan="2"><span class="label label-important">{%=locale.fileupload.error%}</span> {%=locale.fileupload.errors[file.error] || file.error%}</td>
-    {% } else if (o.files.valid && !i) { %}
-    <td>
-      <div class="progress progress-success progress-striped active"><div class="bar" style="width:0%;"></div></div>
-    </td>
-    <td class="start">{% if (!o.options.autoUpload) { %}
-      <button class="btn btn-primary">
-        <i class="icon-upload icon-white"></i>
-        <span>{%=locale.fileupload.start%}</span>
-      </button>
-      {% } %}</td>
-    {% } else { %}
-    <td colspan="2"></td>
-    {% } %}
-    <td class="cancel">{% if (!i) { %}
-      <button class="btn btn-warning">
-        <i class="icon-ban-circle icon-white"></i>
-        <span>{%=locale.fileupload.cancel%}</span>
-      </button>
-      {% } %}</td>
-  </tr>
-  {% } %}
-</script>
-<!-- The template to display files available for download -->
-<script id="template-download" type="text/x-tmpl">
-  {% for (var i=0, file; file=o.files[i]; i++) { %}
-    <tr class="template-download fade">
-      {% if (file.error) { %}
-        <td></td>
-        <td class="name"><span>{%=file.name%}</span></td>
-        <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
-        <td class="error" colspan="2"><span class="label label-important">{%=locale.fileupload.error%}</span> {%=locale.fileupload.errors[file.error] || file.error%}</td>
-        {% } else { %}
-        <td class="preview">{% if (file.thumbnail_url) { %}
-          <a href="{%=file.url%}" title="{%=file.name%}" rel="gallery" download="{%=file.name%}"><img src="{%=file.thumbnail_url%}"></a>
-          {% } %}</td>
-        <td class="name">
-          <a href="{%=file.url%}" title="{%=file.name%}" rel="{%=file.thumbnail_url&&'gallery'%}" download="{%=file.name%}">{%=file.name%}</a>
-        </td>
-        <td class="size"><span>{%=o.formatFileSize(file.size)%}</span></td>
-        <td colspan="2"></td>
-        {% } %}
-      <td class="delete">
-        <button class="btn btn-danger" data-type="{%=file.delete_type%}" data-url="{%=file.delete_url%}">
-          <i class="icon-trash icon-white"></i>
-          <span>{%=locale.fileupload.destroy%}</span>
-        </button>
-        <input type="checkbox" name="delete" value="1">
-      </td>
-    </tr>
-    {% } %}
-</script>
+<%== render "upload_template" %>
+<%== render "download_template" %>
 
 <script type="text/javascript" charset="utf-8">
   $(function () {

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -51,8 +51,8 @@
   };
 </script>
 
-<%== render "upload_template" %>
-<%== render "download_template" %>
+<%= render "upload_template" %>
+<%= render "download_template" %>
 
 <script type="text/javascript" charset="utf-8">
   $(function () {


### PR DESCRIPTION
A minor omission was made that didn't allow thumbnails to show. For completeness thumbnails really should show.

To fix this yourself just add styles and a new hash to `to_jq_upload` like so:

```
class Upload < ActiveRecord::Base
  attr_accessible :upload
  has_attached_file :upload,
    styles: { 
      original: "600x600>", 
      thumbnail: "40x40#" 
    }


  include Rails.application.routes.url_helpers

  def to_jq_upload
    {
      "name" => read_attribute(:upload_file_name),
      "size" => read_attribute(:upload_file_size),
      "url" => upload.url(:original),
      "delete_url" => upload_path(self),
      "delete_type" => "DELETE",
      "thumbnail_url" => upload.url(:thumbnail)
    }
  end

end
```
